### PR TITLE
Set Prettier up to always wrap prose

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,4 @@
+/* eslint-env node */
+module.exports = {
+  proseWrap: "always"
+};


### PR DESCRIPTION
This means Markdown files will be wrapped at 80 characters, improving
readability.