### PR TITLE
Ignore test files when building TypeScript

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,7 @@ const babel = require("rollup-plugin-babel");
 const typescript = require("rollup-plugin-typescript2");
 
 const pkg = require("./package.json");
+const tsconfig = require("./tsconfig.json");
 
 module.exports = {
   input: "src/index.ts",
@@ -22,7 +23,15 @@ module.exports = {
   ],
   plugins: [
     typescript({
-      typescript: require("typescript")
+      typescript: require("typescript"),
+      tsconfigOverride: {
+        exclude: [
+          ...tsconfig.exclude,
+          "**/__tests__/**/*",
+          "**/*.spec.*",
+          "**/*.test.*"
+        ]
+      }
     }),
     babel({
       extensions: [".ts", ".tsx"],


### PR DESCRIPTION
We don't want to distribute any type declarations from the tests.