### PR TITLE
Rename the ES module distributable index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lbh-frontend-react",
-  "main": "dist/index.js",
-  "module": "dist/index.es.js",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
Most React projects use module syntax, so using `index.js` by default makes sense. This also means the types are associated to that file automatically, as they share a name.