### PR TITLE
Create a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+# What?
+
+<!--
+  What new features or changes does this pull request contain?
+
+  Include before and after screenshots, if appropriate.
+  -->
+
+# Why?
+
+<!--
+  What motivates these changes?
+
+  Include any user stories driving this feature, if appropriate.
+  -->
+
+# Notes
+
+<!--
+  Is there anything about the implementation worth calling out to reviewers?
+  -->
+
+# Next steps
+
+<!--
+  Is there any follow up work that needs to be done?
+
+  Consider using a checklist, for example:
+
+  - [ ] do something
+  - [ ] do something else
+  -->
+
+# Jira
+
+**Copy the following into the merge commit body:**
+
+<!--
+  Is this related to a ticket in Jira? If so, add Smart Commit commands here
+  to be included in the merge commit if the PR is merged.
+
+  https://confluence.atlassian.com/fisheye/using-smart-commits-960155400.html
+  -->


### PR DESCRIPTION
# What?

This adds a Pull Request template that matches the format of this pull request body

# Why?

We want to ensure PRs come in with sufficient context to reviewers. We also want to use Jira's smart commits feature, to connect work to tickets. Doing this in feature branch commits causes a lot of duplicate comments / actions in Jira when rebasing, so putting smart commit commands in pull requests means those updates would happen on merge.

# Notes

Note that HTML comments are ignored when rendering Markdown, so the instructions would only appear when creating or editing a PR.

# Next steps

- [ ] propogate this to `remultiform`

# Jira

**Copy this into the merge commit body!**

MT3-221 #comment I've created a PR template for `lbh-frontend-template` for possible reuse across Hackney. See https://github.com/LBHackney-IT/lbh-frontend-react/pull/44 for more information.