### PR TITLE
Modify builds to build a full hierarchy for both CJS and ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "lbh-frontend-react",
   "description": "London Borough of Hackney's React component library",
   "license": "MIT",
-  "main": "dist/all.js",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
   "files": [
     "dist"
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 /* eslint-env node */
+const { dirname } = require("path");
 const babel = require("rollup-plugin-babel");
 const del = require("rollup-plugin-delete");
 const { default: multiInput } = require("rollup-plugin-multi-input");
@@ -10,58 +11,53 @@ const typescript = require("rollup-plugin-typescript2");
 const pkg = require("./package.json");
 const tsconfig = require("./tsconfig.json");
 
-const external = [
-  ...Object.keys(pkg.dependencies || {}),
-  ...Object.keys(pkg.peerDependencies || {})
-];
-
-const plugins = [
-  progress({
-    clearLine: false
-  }),
-  resolve(),
-  postcss(),
-  typescript({
-    typescript: require("typescript"),
-    tsconfigOverride: {
-      exclude: [
-        ...tsconfig.exclude,
-        "**/__tests__/**/*",
-        "**/*.spec.*",
-        "**/*.test.*"
-      ]
-    }
-  }),
-  babel({
-    extensions: [".ts", ".tsx"],
-    exclude: "**/node_modules/**/*"
-  })
-];
-
 module.exports = [
   {
     input: ["src/**/*.ts?(x)", "!**/*.(spec|test).*", "!**/__tests__/**/*"],
-    output: {
-      dir: "dist",
-      format: "es"
-    },
-    external,
+    output: [
+      {
+        dir: dirname(pkg.main),
+        format: "cjs"
+      },
+      {
+        dir: dirname(pkg.module),
+        format: "es"
+      }
+    ],
+    external: [
+      ...Object.keys(pkg.dependencies || {}),
+      ...Object.keys(pkg.peerDependencies || {})
+    ],
     plugins: [
       multiInput(),
       del({
-        targets: ["dist/**/*"],
+        targets: [dirname(pkg.main), dirname(pkg.module)],
         verbose: true
       }),
-      ...plugins
+      progress({
+        clearLine: false
+      }),
+      resolve(),
+      postcss(),
+      typescript({
+        typescript: require("typescript"),
+        useTsconfigDeclarationDir: true,
+        tsconfigOverride: {
+          compilerOptions: {
+            declarationDir: dirname(pkg.types)
+          },
+          exclude: [
+            ...tsconfig.exclude,
+            "**/__tests__/**/*",
+            "**/*.spec.*",
+            "**/*.test.*"
+          ]
+        }
+      }),
+      babel({
+        extensions: [".ts", ".tsx"],
+        exclude: "**/node_modules/**/*"
+      })
     ]
-  },
-  {
-    input: "src/index.ts",
-    output: {
-      file: pkg.main,
-      format: "cjs"
-    },
-    external,
-    plugins
   }
 ];


### PR DESCRIPTION
We want to be able to offer the benefits of being able to import individual components as needed, to reduce bundle sizes, to all consumers of this package. Making this change supports that, while keeping the dependency small by only including type declarations where they will be used (by ESM imports).