### PR TITLE
MT3-221 #ready-for-test #comment Suggest using the PR title for Jira smart commits

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,14 @@
+<!--
+  Is this related to a ticket in Jira? If so, add Smart Commit commands to the
+  PR title to be automatically included in the merge commit if the PR is merged.
+
+  For example:
+
+  MT3-221 #ready-for-test #comment Create a pull request template
+
+  https://confluence.atlassian.com/fisheye/using-smart-commits-960155400.html
+  -->
+
 # What?
 
 <!--
@@ -29,15 +40,4 @@
 
   - [ ] do something
   - [ ] do something else
-  -->
-
-# Jira
-
-**Copy the following into the merge commit body:**
-
-<!--
-  Is this related to a ticket in Jira? If so, add Smart Commit commands here
-  to be included in the merge commit if the PR is merged.
-
-  https://confluence.atlassian.com/fisheye/using-smart-commits-960155400.html
   -->


### PR DESCRIPTION
# What?

This removes the Jira section from the template in favour of a comment recommending using the PR title (as this PR does) for smart commits.

# Why?

GitHub prefills the merge commit with the PR title, so this reduces the overhead in doing merges, as it doesn't require manual copy operations.