### PR TITLE
MT3-237 #ready-for-test #comment Add Link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,6 @@ and this project adheres to
 - SASS support
 - `lbh-frontend` library to style components
 - `ErrorMessage` component
+- `ComponentRegister` class for linking external components to library
+  components
+- `Link` component

--- a/docs/adr/0009-build-a-component-register.md
+++ b/docs/adr/0009-build-a-component-register.md
@@ -1,0 +1,33 @@
+# 9. Build a component register
+
+Date: 2019-11-11
+
+## Status
+
+Accepted
+
+## Context
+
+There will be times when the user has external components that they wish to
+connect to components within the component library, so they can use the core
+functionality of those external components, while also using the Hackney styles.
+An example of this is routing, where they may have custom anchor components
+needed to interface with that their routing library. In order to do this, we
+will need to create a way for the user to tell `lbh-frontend-react` to use
+specific components in certain roles.
+
+## Decision
+
+We will build a component register, where the user can register custom
+components to be used by the components in this library.
+
+## Consequences
+
+If the user wishes to use certain components within the library in a way that
+interacts with their external components, they will be able to register them. We
+will need to indicate this to the user through documentation, so that they know
+which components can be registered.
+
+Components provided to the component registry at runtime need to conform to a
+certain shape, and accept certain props. We can mitigate this with suitable
+documentation.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 /* eslint-env node */
 module.exports = {
   preset: "ts-jest",
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   moduleNameMapper: {
     "^.+\\.scss$": "identity-obj-proxy"
   },

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,5 @@
+import { ComponentRegister } from "./src/ComponentRegister";
+
+afterEach(() => {
+  ComponentRegister.reset();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -3859,13 +3859,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3879,8 +3877,7 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -4001,7 +3998,6 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4107,7 +4103,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4285,8 +4280,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -50,7 +50,8 @@ module.exports = [
             ...tsconfig.exclude,
             "**/__tests__/**/*",
             "**/*.spec.*",
-            "**/*.test.*"
+            "**/*.test.*",
+            "**/*.setup.*"
           ]
         }
       }),

--- a/src/ComponentRegister.test.tsx
+++ b/src/ComponentRegister.test.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+
+import {
+  ComponentRegister,
+  LinkComponent,
+  LinkComponentProps,
+  defaultComponentOptions
+} from "./ComponentRegister";
+
+const TestLinkComponent: LinkComponent = ({
+  href,
+  children
+}: LinkComponentProps) => <div data-href={href}>{children}</div>;
+
+const defaultLinkComponentOption = defaultComponentOptions.components.Link;
+
+describe("defaultComponentOptions", () => {
+  it("has the correct properties", () => {
+    expect(defaultComponentOptions).toEqual({
+      components: {
+        Link: "a"
+      }
+    });
+  });
+});
+
+describe(".init()", () => {
+  it("registers all of the components provided", () => {
+    ComponentRegister.init({
+      components: {
+        Link: TestLinkComponent
+      }
+    });
+
+    expect(ComponentRegister.Link).toStrictEqual(TestLinkComponent);
+  });
+
+  it("does not alter properties if none are provided", () => {
+    ComponentRegister.init();
+
+    expect(ComponentRegister.Link).toStrictEqual(defaultLinkComponentOption);
+  });
+});
+
+describe(".Link", () => {
+  it("defaults to 'a'", () => {
+    expect(ComponentRegister.Link).toEqual(defaultLinkComponentOption);
+  });
+});
+
+describe(".reset()", () => {
+  it("resets ComponentRegister properties back to their default state", () => {
+    ComponentRegister.init({
+      components: {
+        Link: TestLinkComponent
+      }
+    });
+
+    ComponentRegister.reset();
+    expect(ComponentRegister.Link).toEqual(defaultLinkComponentOption);
+  });
+});

--- a/src/ComponentRegister.ts
+++ b/src/ComponentRegister.ts
@@ -1,0 +1,96 @@
+import { ElementType, ReactNode } from "react";
+
+/**
+ * The property types for {@link LinkComponent}.
+ *
+ * @property {string} [className]
+ * @property {string} href
+ * @property {ReactNode} children
+ */
+export interface LinkComponentProps {
+  className?: string;
+  href: string;
+  children: ReactNode;
+}
+
+/**
+ * The type of a valid link component to be passed to {@link ComponentRegister}.
+ * It allows any valid React component (including tag strings) that accept
+ * {@link LinkComponentProps} as proptypes.
+ */
+export type LinkComponent = ElementType<LinkComponentProps>;
+
+interface ComponentRegisterDefaultOptions {
+  components: {
+    Link: LinkComponent;
+  };
+}
+
+/**
+ * The default options for {@link ComponentRegister}.
+ */
+export const defaultComponentOptions: ComponentRegisterDefaultOptions = {
+  components: {
+    Link: "a"
+  }
+};
+
+/**
+ * The properties for registering components.
+ *
+ * @property {object} [components] - The components to register
+ * @property {LinkComponent} [components.Link] - The component to use internally
+ * for handling links. Defaults to `"a"`.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ComponentRegisterOptions
+  extends Partial<ComponentRegisterDefaultOptions> {}
+
+/**
+ * A register of components to use with library components with sensible
+ * defaults. Most users will never need to interact with this. It exists to
+ * support customization of library component behaviour.
+ */
+export class ComponentRegister {
+  /**
+   * @static The {@link LinkComponent} to allow `lbh-frontend-react` to hook
+   * into routers or other custom linking libraries.
+   *
+   * Defaults to `"a"`. See {@link defaultComponentOptions}.
+   */
+  static Link: LinkComponent = defaultComponentOptions.components.Link;
+
+  /**
+   * @static Resets the component register to its defaults. See
+   * {@link defaultComponentOptions} for those defaults.
+   */
+  static reset(): void {
+    this.init(defaultComponentOptions);
+  }
+
+  /**
+   * @static Initializes {@link ComponentRegister} with the provided options.
+   *
+   * This is how you set component options en masse, and is the preferred method
+   * for setting custom components.
+   *
+   * @example
+   * // To set `lbh-frontend-react` up to use React Router's `Link` component.
+   * ComponentRegister.init({
+   *   components.
+   *   Link: ({ className, href, children }) => (
+   *     <ReactRouter.Link className={className} to={href}>
+   *       {children}
+   *     </ReactRouter.Link>
+   *   )
+   * });
+   *
+   * @param {ComponentRegisterOptions} [options] - Options to customize the
+   * underlying components used by library components.
+   */
+  static init({ components }: ComponentRegisterOptions = {}): void {
+    if (components && components.Link) {
+      this.Link = components.Link;
+    }
+  }
+}

--- a/src/components/Link.test.tsx
+++ b/src/components/Link.test.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { create } from "react-test-renderer";
+
+import { Link } from "./Link";
+
+it("renders correctly with all props", () => {
+  const component = create(
+    <Link id="testId" className="class1" href="/">
+      Link
+    </Link>
+  );
+  expect(component).toMatchSnapshot();
+});
+
+it("renders with only required props", () => {
+  const component = create(<Link href="/">Link</Link>);
+  expect(component).toMatchSnapshot();
+});

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,0 +1,55 @@
+import React, { FunctionComponent, ReactElement, ReactNode } from "react";
+import classNames from "classnames";
+import PropTypes from "prop-types";
+
+import { ComponentRegister } from "../ComponentRegister";
+
+import "lbh-frontend/lbh/core/_links.scss";
+
+/**
+ * The property types for {@link Link}.
+ *
+ * @param {string} [id]
+ * @param {string} [className]
+ * @param {string} href
+ * @param {ReactNode} children
+ */
+export interface LinkProps {
+  id?: string;
+  className?: string;
+  href: string;
+  children: ReactNode;
+}
+
+/**
+ * A component for creating an anchor linking to other pages. You can customize
+ * the component used internally for integration with routers using
+ * {@link ComponentRegister.init}. By default, it uses an <a> tag.
+ *
+ * @param {LinkProps} props
+ *
+ * @returns {ReactElement}
+ */
+export const Link: FunctionComponent<LinkProps> = ({
+  id,
+  className,
+  href,
+  children
+}: LinkProps): ReactElement => {
+  return (
+    <ComponentRegister.Link
+      id={id}
+      className={classNames("govuk-link lbh-link", className)}
+      href={href}
+    >
+      {children}
+    </ComponentRegister.Link>
+  );
+};
+
+Link.propTypes = {
+  id: PropTypes.string,
+  className: PropTypes.string,
+  href: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired
+};

--- a/src/components/__snapshots__/Link.test.tsx.snap
+++ b/src/components/__snapshots__/Link.test.tsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly with all props 1`] = `
+<a
+  className="govuk-link lbh-link class1"
+  href="/"
+  id="testId"
+>
+  Link
+</a>
+`;
+
+exports[`renders with only required props 1`] = `
+<a
+  className="govuk-link lbh-link"
+  href="/"
+>
+  Link
+</a>
+`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,6 @@
     "jsx": "react",
     "noEmit": true
   },
-  "include": ["src"],
+  "include": ["src", "**/*.setup.*"],
   "exclude": ["**/node_modules/**/*"]
 }


### PR DESCRIPTION
`Link` is a wrapper for the current routing solution within the consumer application, given that the component used in the library is initialised within `ComponentRegister`. If not initialised, `Link` component will default to an anchor tag.

<!--
  Is this related to a ticket in Jira? If so, add Smart Commit commands to the
  PR title to be automatically included in the merge commit if the PR is merged.

  For example:

  MT3-221 #ready-for-test #comment Create a pull request template

  https://confluence.atlassian.com/fisheye/using-smart-commits-960155400.html
  -->

# What?

<!--
  What new features or changes does this pull request contain?

  Include before and after screenshots, if appropriate.
  -->

Adds a component register class that allows the host application to utilise the styles of [lbh-frontend](https://github.com/LBHackney-IT/lbh-frontend) for components that may need to be defined by the host. Also adds a link wrapper component that the host can use when they have registered their respective link component.

# Why?

<!--
  What motivates these changes?

  Include any user stories driving this feature, if appropriate.
  -->

The user will need to link between pages within their application. They may also be using one of many different routing methods. The component register allows the host to register any of these methods, so they can use a corresponding link component wrapper that has the `lbh-frontend` styles applied to it. 

# Notes

<!--
  Is there anything about the implementation worth calling out to reviewers?
  -->
ComponentRegister may need to be made more generic in the future to accept more than only link components.

# References 

`lbh-frontend` library: [Github](https://github.com/LBHackney-IT/LBH-frontend/tree/master/src/lbh/components/lbh-header) | [Style guide](https://lbh-frontend.herokuapp.com/examples/typography) (scroll down for links)
`govuk-frontend` library : [Github](https://github.com/alphagov/govuk-frontend/tree/master/src/govuk/components/header) | [Style guide](https://design-system.service.gov.uk/components/header/)
