### PR TITLE
Switch away from using default exports to using only named exports

### DIFF
--- a/barrelsby.json
+++ b/barrelsby.json
@@ -1,6 +1,5 @@
 {
   "directory": "src",
   "delete": true,
-  "exclude": ["^.*/__tests__/.+\\.tsx?$", "^.+\\.(spec|test)\\.tsx?$"],
-  "exportDefault": true
+  "exclude": ["^.*/__tests__/.+\\.tsx?$", "^.+\\.(spec|test)\\.tsx?$"]
 }

--- a/src/components/ErrorMessage.test.tsx
+++ b/src/components/ErrorMessage.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { create } from "react-test-renderer";
 
-import ErrorMessage from "./ErrorMessage";
+import { ErrorMessage } from "./ErrorMessage";
 
 it("renders correctly with all props", () => {
   const component = create(

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -11,7 +11,7 @@ export type ErrorMessageProps = {
   children?: ReactNode;
 };
 
-const ErrorMessage: FunctionComponent<ErrorMessageProps> = ({
+export const ErrorMessage: FunctionComponent<ErrorMessageProps> = ({
   id,
   className,
   visuallyHiddenText,
@@ -42,5 +42,3 @@ ErrorMessage.propTypes = {
 ErrorMessage.defaultProps = {
   visuallyHiddenText: "Error"
 };
-
-export default ErrorMessage;


### PR DESCRIPTION
# What?

This changes `ErrorComponent` to be a named export rather than a default export, and stops Barrelsby from including default exports in the `index.ts` it generates.

# Why?

Built CommonJS files with both named and default exports end up looking like:

```
exports.NamedThing = NamedThing;
exports.default = DefaultThing;
```

To access `DefaultThing` in that example, you would need to use `require("package/DefaultThing").default` which is less than ideal.