### PR TITLE
MT3-248 #ready-for-test #comment Add Hint component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ and this project adheres to
 - `ComponentRegister` class for linking external components to library
   components
 - `Link` component
+- `Hint` component

--- a/src/components/Hint.scss
+++ b/src/components/Hint.scss
@@ -1,0 +1,2 @@
+@import "node_modules/lbh-frontend/lbh/core/_typography.scss";
+@import "node_modules/lbh-frontend/lbh/core/_hint.scss";

--- a/src/components/Hint.test.tsx
+++ b/src/components/Hint.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { create } from "react-test-renderer";
+
+import { Hint } from "./Hint";
+
+it("renders correctly with all props", () => {
+  const component = create(
+    <Hint id="test" className="class1 class2">
+      Test
+    </Hint>
+  );
+
+  expect(component).toMatchSnapshot();
+});
+
+it("renders correctly without optional props", () => {
+  const component = create(<Hint>Test</Hint>);
+
+  expect(component).toMatchSnapshot();
+});

--- a/src/components/Hint.tsx
+++ b/src/components/Hint.tsx
@@ -1,0 +1,41 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React, { FunctionComponent, ReactElement, ReactNode } from "react";
+
+import "./Hint.scss";
+
+/**
+ * The property types for {@link Hint}.
+ *
+ * @property {string} [id]
+ * @property {string} [className]
+ * @property {ReactNode} children - The hint message
+ */
+export interface HintProps {
+  id?: string;
+  className?: string;
+  children: ReactNode;
+}
+
+/**
+ * A component for providing hint text to users.
+ *
+ * @param {HintProps} props
+ *
+ * @returns {ReactElement}
+ */
+export const Hint: FunctionComponent<HintProps> = ({
+  id,
+  className,
+  children
+}: HintProps): ReactElement => (
+  <span id={id} className={classNames("govuk-hint", className)}>
+    {children}
+  </span>
+);
+
+Hint.propTypes = {
+  id: PropTypes.string,
+  className: PropTypes.string,
+  children: PropTypes.node.isRequired
+};

--- a/src/components/__snapshots__/Hint.test.tsx.snap
+++ b/src/components/__snapshots__/Hint.test.tsx.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly with all props 1`] = `
+<span
+  className="govuk-hint class1 class2"
+  id="test"
+>
+  Test
+</span>
+`;
+
+exports[`renders correctly without optional props 1`] = `
+<span
+  className="govuk-hint"
+>
+  Test
+</span>
+`;


### PR DESCRIPTION
<!--
  Is this related to a ticket in Jira? If so, add Smart Commit commands to the
  PR title to be automatically included in the merge commit if the PR is merged.

  For example:

  MT3-221 #ready-for-test #comment Create a pull request template

  https://confluence.atlassian.com/fisheye/using-smart-commits-960155400.html
  -->

# What?

Added Hint component to be used with inputs.
<!--
  What new features or changes does this pull request contain?

  Include before and after screenshots, if appropriate.
  -->

# Why?

Labels for input fields may require a hint so that the user understands what they need to do easier. 
<!--
  What motivates these changes?

  Include any user stories driving this feature, if appropriate.
  -->

# References 

`lbh-frontend` library: [Github](https://github.com/LBHackney-IT/LBH-frontend/tree/master/src/lbh/components/lbh-header) | [Style guide](https://lbh-frontend.herokuapp.com/components/lbh-input) (see input with hint text)
`govuk-frontend` library : [Github](https://github.com/alphagov/govuk-frontend/tree/master/src/govuk/components/hint) | [Style guide](https://design-system.service.gov.uk/components/text-input/#hint-text)

