### PR TITLE
MT3-247 #ready-for-test #comment Add Label component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ and this project adheres to
   components
 - `Link` component
 - `Hint` component
+- `Label` component

--- a/src/components/Label.scss
+++ b/src/components/Label.scss
@@ -1,0 +1,2 @@
+@import "node_modules/lbh-frontend/lbh/core/_typography.scss";
+@import "node_modules/lbh-frontend/lbh/core/_label.scss";

--- a/src/components/Label.test.tsx
+++ b/src/components/Label.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { create } from "react-test-renderer";
+
+import { Label } from "./Label";
+
+it("renders correctly with all props", () => {
+  const component = create(
+    <Label id="testId" className="class1 class2" labelFor="test">
+      Test
+    </Label>
+  );
+
+  expect(component).toMatchSnapshot();
+});
+
+it("renders correctly without optional props", () => {
+  const component = create(<Label>Test</Label>);
+
+  expect(component).toMatchSnapshot();
+});

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -1,0 +1,49 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React, { FunctionComponent, ReactNode, ReactElement } from "react";
+
+import "./Label.scss";
+
+/**
+ * The property types for {@link Label}.
+ *
+ * @property {string} [id]
+ * @property {string} [className]
+ * @property {string} [labelFor]
+ * @property {ReactNode} children - The label content
+ */
+export interface LabelProps {
+  id?: string;
+  className?: string;
+  labelFor?: string;
+  children: ReactNode;
+}
+
+/**
+ * A component for providing labels on inputs.
+ *
+ * @param {LabelProps} props
+ *
+ * @returns {ReactElement}
+ */
+export const Label: FunctionComponent<LabelProps> = ({
+  id,
+  className,
+  labelFor,
+  children
+}: LabelProps): ReactElement => (
+  <label
+    id={id}
+    className={classNames("govuk-label", "lbh-label", className)}
+    htmlFor={labelFor}
+  >
+    {children}
+  </label>
+);
+
+Label.propTypes = {
+  id: PropTypes.string,
+  className: PropTypes.string,
+  labelFor: PropTypes.string,
+  children: PropTypes.node.isRequired
+};

--- a/src/components/__snapshots__/Label.test.tsx.snap
+++ b/src/components/__snapshots__/Label.test.tsx.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly with all props 1`] = `
+<label
+  className="govuk-label lbh-label class1 class2"
+  htmlFor="test"
+  id="testId"
+>
+  Test
+</label>
+`;
+
+exports[`renders correctly without optional props 1`] = `
+<label
+  className="govuk-label lbh-label"
+>
+  Test
+</label>
+`;


### PR DESCRIPTION
<!--
  Is this related to a ticket in Jira? If so, add Smart Commit commands to the
  PR title to be automatically included in the merge commit if the PR is merged.

  For example:

  MT3-221 #ready-for-test #comment Create a pull request template

  https://confluence.atlassian.com/fisheye/using-smart-commits-960155400.html
  -->

# What?

Added label component to be used with inputs.
<!--
  What new features or changes does this pull request contain?

  Include before and after screenshots, if appropriate.
  -->

# Why?

In order to be accessible, inputs will need to have a label. 
<!--
  What motivates these changes?

  Include any user stories driving this feature, if appropriate.
  -->

# References 

`lbh-frontend` library: [Github](https://github.com/LBHackney-IT/LBH-frontend/blob/master/src/lbh/core/_label.scss) | [Style guide](https://lbh-frontend.herokuapp.com/components/lbh-input) (see inputs with labels)
`govuk-frontend` library : [Github](https://github.com/alphagov/govuk-frontend/tree/master/src/govuk/components/label) | [Style guide](https://design-system.service.gov.uk/components/text-input/) (see inputs with labels)
