### PR TITLE
Disable Jekyll for the entire `docs/` directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4000,8 +4000,7 @@
         },
         "ms": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "node-pre-gyp": {
           "version": "0.12.0",
@@ -4144,8 +4143,7 @@
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "sax": {
           "version": "1.2.4",
@@ -9607,28 +9605,6 @@
         "jquery": "^3.4.1",
         "lunr": "^2.3.6",
         "underscore": "^1.9.1"
-      }
-    },
-    "typedoc-plugin-nojekyll": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-nojekyll/-/typedoc-plugin-nojekyll-1.0.1.tgz",
-      "integrity": "sha512-hdFMhn0vAFCwepihSaVVs5yyImjo2FCX/OVQW89lrrqoARYHlAchOki4BQug23UqFSrYdykUu8yP4gD0M48qbw==",
-      "dev": true,
-      "requires": {
-        "fs-extra": "^6.0.1"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
-          "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        }
       }
     },
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "ts-jest": "^24.1.0",
     "tslib": "^1.10.0",
     "typedoc": "^0.15.0",
-    "typedoc-plugin-nojekyll": "^1.0.1",
     "typescript": "^3.7.2"
   },
   "husky": {


### PR DESCRIPTION
# What?

Disable Jekyll for the entire `docs/` directory.

# Why?

We serve GitHub pages from the root of `docs/`, and Jekyll ignores all files with a leading underscore, by default.