### PR TITLE
MT3-270 #comment Update `lbh-frontend-react` code owners to use the MaT GitHub team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,13 +10,13 @@
 /*            @erbridge @CJWaszczuk @LBHELewis
 
 # Any changes in a directory starting with `.` in the root of the repository.
-/.*/          @erbridge @CJWaszczuk @LBHMGeorgieva @lbhssandilya @Duslerke @LBHELewis
+/.*/          @LBHackney-IT/mat-developers @LBHELewis
 
 /docs/        @erbridge @CJWaszczuk @LBHELewis
-/docs/adr/    @erbridge @CJWaszczuk @LBHMGeorgieva @lbhssandilya @Duslerke @LBHELewis
+/docs/adr/    @LBHackney-IT/mat-developers @LBHELewis
 
-/src/         @erbridge @CJWaszczuk @LBHMGeorgieva @lbhssandilya @Duslerke @LBHELewis
-/examples/    @erbridge @CJWaszczuk @LBHMGeorgieva @lbhssandilya @Duslerke @LBHELewis
+/src/         @LBHackney-IT/mat-developers @LBHELewis
+/examples/    @LBHackney-IT/mat-developers @LBHELewis
 
 # We disable these to reduce noise from Dependabot.
 package.json


### PR DESCRIPTION
# What?

Update to use the MaT GitHub team.

# Why?

That means we don't need to update these individual repositories everytime the team changes.
