### PR TITLE
Replace internal sass stylesheet with direct import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6635,9 +6635,9 @@
       "dev": true
     },
     "lbh-frontend": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/lbh-frontend/-/lbh-frontend-1.3.0.tgz",
-      "integrity": "sha512-sM3hkKZpSA00SqDS2SvkNZ64UDE36iZ6cmwIhzmvEOlGFvV5ZVbLFAF+WQ8weA5BzdMLmEvlwnQEMQAYAK4Piw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/lbh-frontend/-/lbh-frontend-1.4.0.tgz",
+      "integrity": "sha512-HHVFsL46bg7ThyVP7Z+uIikS4SWM044sy0QpMN9fzNktLUDafK+IG5WwsI0/iOsU0r+gYDQa8g2z9EN/zPMDKQ==",
       "dev": true
     },
     "lcid": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "husky": "^3.1.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.9.0",
-    "lbh-frontend": "^1.3.0",
+    "lbh-frontend": "^1.4.0",
     "node-sass": "^4.13.0",
     "prettier": "^1.19.1",
     "pretty-quick": "^2.0.1",

--- a/src/components/Hint.scss
+++ b/src/components/Hint.scss
@@ -1,2 +1,0 @@
-@import "node_modules/lbh-frontend/lbh/core/_typography.scss";
-@import "node_modules/lbh-frontend/lbh/core/_hint.scss";

--- a/src/components/Hint.tsx
+++ b/src/components/Hint.tsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 import React from "react";
 
-import "./Hint.scss";
+import "lbh-frontend/lbh/components/lbh-hint/_hint.scss";
 
 /**
  * The proptypes for {@link Hint}.

--- a/src/components/Label.scss
+++ b/src/components/Label.scss
@@ -1,2 +1,0 @@
-@import "node_modules/lbh-frontend/lbh/core/_typography.scss";
-@import "node_modules/lbh-frontend/lbh/core/_label.scss";

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 import React from "react";
 
-import "./Label.scss";
+import "lbh-frontend/lbh/components/lbh-label/label.scss";
 
 /**
  * The property types for {@link Label}.


### PR DESCRIPTION
lbh-frontend bug for extending has been fixed, so we no longer need to manually import a set of sass files into our own stylesheet. We can now directly import the component stylesheet.

<!--
  Is this related to a ticket in Jira? If so, add Smart Commit commands to the
  PR title to be automatically included in the merge commit if the PR is merged.

  For example:

  MT3-221 #ready-for-test #comment Create a pull request template

  https://confluence.atlassian.com/fisheye/using-smart-commits-960155400.html
  -->

# What?
Removed internal hint scss file, imported hint scss file directly from `lbh-frontend` instead.
<!--
  What new features or changes does this pull request contain?

  Include before and after screenshots, if appropriate.
  -->

# Why?

The previous solution was a workaround for a file not being importable without another files due to extensions. This has been fixed.
<!--
  What motivates these changes?

  Include any user stories driving this feature, if appropriate.
  -->

# Notes
Requires `lbh-frontend-react` to have the most recent version of `lbh-frontend`
<!--
  Is there anything about the implementation worth calling out to reviewers?
  -->

# References 

[Pull request](https://github.com/LBHackney-IT/LBH-frontend/pull/46/) in `lbh-frontend` that adds the hint component 