### PR TITLE
Ignore `/bin/` from Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 .github/CODEOWNERS
 node_modules/
 
+/bin/
 /dist/
 /docs/api/
 /src/index.ts


### PR DESCRIPTION
# Why?

It doesn't know how to handle shell scripts.
