### PR TITLE
Make prettier ignore all index files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,7 +4,7 @@ node_modules/
 /bin/
 /dist/
 /docs/api/
-/src/index.ts
+/src/**/index.ts
 
 LICENCE
 *.snap


### PR DESCRIPTION
<!--
  Is this related to a ticket in Jira? If so, add Smart Commit commands to the
  PR title to be automatically included in the merge commit if the PR is merged.

  For example:

  MT3-221 #ready-for-test #comment Create a pull request template

  https://confluence.atlassian.com/fisheye/using-smart-commits-960155400.html
  -->

# What?
Makes prettier ignore all index files.

<!--
  What new features or changes does this pull request contain?

  Include before and after screenshots, if appropriate.
  -->

# Why?

Prettier currently only ignores the prettier file inside the src
directory. Now that we will have index files in most directories,
we don't want it formatting them all.
<!--
  What motivates these changes?

  Include any user stories driving this feature, if appropriate.
  -->