### PR TITLE
Fix eslint and remove unused import

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,4 @@
 node_modules/
 
 /dist/
-/src/index.ts
+/src/**/index.ts

--- a/docs/api/interfaces/_src_components_icons_startbuttonicon_.startbuttoniconprops.html
+++ b/docs/api/interfaces/_src_components_icons_startbuttonicon_.startbuttoniconprops.html
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">class<wbr>Name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/LBHackney-IT/lbh-frontend-react/blob/master/src/components/icons/StartButtonIcon.tsx#L9">src/components/icons/StartButtonIcon.tsx:9</a></li>
+							<li>Defined in <a href="https://github.com/LBHackney-IT/lbh-frontend-react/blob/master/src/components/icons/StartButtonIcon.tsx#L8">src/components/icons/StartButtonIcon.tsx:8</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/api/modules/_src_components_icons_startbuttonicon_.html
+++ b/docs/api/modules/_src_components_icons_startbuttonicon_.html
@@ -97,7 +97,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/LBHackney-IT/lbh-frontend-react/blob/master/src/components/icons/StartButtonIcon.tsx#L15">src/components/icons/StartButtonIcon.tsx:15</a></li>
+									<li>Defined in <a href="https://github.com/LBHackney-IT/lbh-frontend-react/blob/master/src/components/icons/StartButtonIcon.tsx#L14">src/components/icons/StartButtonIcon.tsx:14</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/src/components/icons/StartButtonIcon.tsx
+++ b/src/components/icons/StartButtonIcon.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import classNames from "classnames";
 
 /**
  * The proptypes for {@link StartButtonIcon}.


### PR DESCRIPTION

# What?

Made ESLint ignore all index files in src and below.
Fixed ESLint warning on unused imports 
<!--
  What new features or changes does this pull request contain?

  Include before and after screenshots, if appropriate.
  -->

# Why?
ESLint shouldn't be linting generated code
Warnings are bad
<!--
  What motivates these changes?

  Include any user stories driving this feature, if appropriate.
  -->

