### PR TITLE
Make some improvements to `bin/bump-version`

### DIFF
--- a/bin/bump-version
+++ b/bin/bump-version
@@ -26,10 +26,6 @@ if [[ $CHANGELOG_UPDATED != "y" ]] && [[ $CHANGELOG_UPDATED != "Y" ]]; then
   exit 1
 fi
 
-npm install
-
-bin/check-git
-
 npm version "$NEW_VERSION"
 
 git add package.json package-lock.json

--- a/bin/bump-version
+++ b/bin/bump-version
@@ -14,8 +14,8 @@ cd "$ROOT_DIR"
 
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-if ! [[ $CURRENT_BRANCH =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "Expected to be on a branch in the form of release/vx.y.z"
+if [[ $CURRENT_BRANCH != "release/v$NEW_VERSION" ]]; then
+  echo "Expected to be on the branch: \"release/v$NEW_VERSION\""
   exit 1
 fi
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "format": "prettier --write '**/*'",
     "format:check": "prettier --check '**/*'",
     "prepare": "npm run build",
-    "preversion": "npm test && bin/check-git"
+    "preversion": "npm install && npm test && bin/check-git"
   },
   "peerDependencies": {
     "react": ">= 16"


### PR DESCRIPTION
Require the branch to match the version number. We know what version we're releasing, so we can enforce the naming convention.

Move `npm install` into `preversion`. We want to run it before the tests regardless of how `npm version` is called.