### PR TITLE
Add labels to the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.md
@@ -3,6 +3,8 @@ name: Report bug
 about:
   Something didn't behave as expected. If this is about styling components, see
   below.
+labels:
+  - bug
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/02_missing_feature_report.md
+++ b/.github/ISSUE_TEMPLATE/02_missing_feature_report.md
@@ -3,6 +3,9 @@ name: Report missing feature
 about:
   Some component, behaviour, or option that exists in `lbh-frontend` doesn't
   exist here.
+labels:
+  - enhancement
+  - missing feature
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/03_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/03_feature_request.md
@@ -1,6 +1,8 @@
 ---
 name: Request feature
 about: You have an idea for a new feature.
+labels:
+  - enhancement
 ---
 
 <!--


### PR DESCRIPTION
This automatically assigns labels to issues based on the type of issue.