### PR TITLE
Add @babel/runtime-corejs2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - `List` component
 
+### Fixed
+
+- Added `@babel/runetime-corejs2` to fix issues with the build process
+
 ## [0.0.2] - 05-12-2019
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1375,6 +1375,24 @@
         "@babel/plugin-transform-react-jsx-source": "^7.7.4"
       }
     },
+    "@babel/runtime-corejs2": {
+      "version": "7.7.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.6.tgz",
+      "integrity": "sha512-QYp/8xdH8iMin3pH5gtT/rUuttVfIcOhWBC3wh9Eh/qs4jEe39+3DpCDLgWXhMQgiCTOH8mrLSvQ0OHOCcox9g==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        }
+      }
+    },
     "@babel/template": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
@@ -9848,6 +9866,12 @@
         "regenerate": "^1.4.0"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+      "dev": true
+    },
     "regenerator-transform": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
@@ -11628,6 +11652,7 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.2.tgz",
       "integrity": "sha512-uhRwZcANNWVLrxLfNFEdltoPNhECUR3lc+UdJoG9CBpMcSnKyWA94tc3eAujB1GcMY5Uwq8ZMp4qWpxWYDQmaA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "commander": "~2.20.3",
         "source-map": "~0.6.1"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@babel/core": "^7.7.5",
     "@babel/preset-env": "^7.7.1",
     "@babel/preset-react": "^7.7.4",
+    "@babel/runtime-corejs2": "^7.7.6",
     "@types/classnames": "^2.2.9",
     "@types/enzyme": "^3.10.3",
     "@types/enzyme-adapter-react-16": "^1.0.5",


### PR DESCRIPTION
@babel/runtime-corejs2 is needed to build the library correctly. Given that we now have components that require this, we need it to be installed so that consumer applications don't run into errors looking for it.