### PR TITLE
Make container a div tag instead of span

### DIFF
--- a/src/components/Container.test.tsx
+++ b/src/components/Container.test.tsx
@@ -11,12 +11,12 @@ it("renders correctly with all props", () => {
   );
 
   expect(component).toMatchInlineSnapshot(`
-    <span
+    <div
       className="govuk-container lbh-container class1 class2"
       id="test"
     >
       Test
-    </span>
+    </div>
   `);
 });
 
@@ -24,10 +24,10 @@ it("renders correctly without optional props", () => {
   const component = create(<Container>Test</Container>);
 
   expect(component).toMatchInlineSnapshot(`
-    <span
+    <div
       className="govuk-container lbh-container"
     >
       Test
-    </span>
+    </div>
   `);
 });

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -27,12 +27,12 @@ export const Container: React.FunctionComponent<ContainerProps> = (
   const { id, className, children } = props;
 
   return (
-    <span
+    <div
       id={id}
       className={classNames("govuk-container", "lbh-container", className)}
     >
       {children}
-    </span>
+    </div>
   );
 };
 


### PR DESCRIPTION
<!--
  Is this related to a ticket in Jira? If so, add Smart Commit commands to the
  PR title to be automatically included in the merge commit if the PR is merged.

  For example:

  MT3-221 #ready-for-test #comment Create a pull request template

  https://confluence.atlassian.com/fisheye/using-smart-commits-960155400.html
  -->

# What?
Change container component to be a `<div>` rather than a `<span>`
<!--
  What new features or changes does this pull request contain?

  Include before and after screenshots, if appropriate.
  -->

# Why?
Container is meant to be a `<div>`, currently is a `<span>`, probably a C & P issues 
<!--
  What motivates these changes?

  Include any user stories driving this feature, if appropriate.
  -->
