### PR TITLE
Make component return types compatible with `children` props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to
 
 - Support for `aria-*` and `data-*` attributes for all components
 
+### Fixed
+
+- Made component return types `React.ReactElement`s rather than `JSX.Element`s
+  to make them compatible with `children` props outside of JSX
+
 ## [0.0.4] - 10-12-2019
 
 ### Added

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -83,7 +83,7 @@ export class Button extends React.Component<ButtonProps> {
   /**
    * @ignore
    */
-  render(): JSX.Element {
+  render(): React.ReactElement {
     const {
       id,
       className,

--- a/src/components/Button/InputButton.tsx
+++ b/src/components/Button/InputButton.tsx
@@ -74,7 +74,7 @@ export class InputButton extends React.Component<InputButtonProps> {
   /**
    * @ignore
    */
-  render(): JSX.Element {
+  render(): React.ReactElement {
     const {
       id,
       className,

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -29,7 +29,7 @@ export interface ContainerProps extends React.AriaAttributes, DataAttributes {
  */
 export const Container: React.FunctionComponent<ContainerProps> = (
   props: ContainerProps
-): JSX.Element => {
+): React.ReactElement => {
   const { id, className, children } = props;
 
   const extraAttributes = Attributes.ariaAndData(props);

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -30,7 +30,7 @@ export interface ErrorMessageProps
  */
 export const ErrorMessage: React.FunctionComponent<ErrorMessageProps> = (
   props: ErrorMessageProps
-): JSX.Element => {
+): React.ReactElement => {
   const { id, className, visuallyHiddenText, children } = props;
 
   const extraAttributes = Attributes.ariaAndData(props);

--- a/src/components/Fieldset/Fieldset.tsx
+++ b/src/components/Fieldset/Fieldset.tsx
@@ -21,7 +21,7 @@ export interface FieldsetProps extends React.AriaAttributes, DataAttributes {
    * The legend for the fieldset. You should pass in a {@link FieldsetLegend}
    * component.
    */
-  legend?: JSX.Element;
+  legend?: React.ReactNode;
   describedBy?: string;
   children: React.ReactNode;
 }
@@ -31,7 +31,7 @@ export interface FieldsetProps extends React.AriaAttributes, DataAttributes {
  */
 export const Fieldset: React.FunctionComponent<FieldsetProps> = (
   props: FieldsetProps
-): JSX.Element => {
+): React.ReactElement => {
   const { id, className, legend, role, describedBy, children } = props;
 
   const extraAttributes = Attributes.ariaAndData(props);

--- a/src/components/Fieldset/FieldsetLegend.tsx
+++ b/src/components/Fieldset/FieldsetLegend.tsx
@@ -49,7 +49,7 @@ export interface FieldsetLegendProps
  */
 export const FieldsetLegend: React.FunctionComponent<FieldsetLegendProps> = (
   props: FieldsetLegendProps
-): JSX.Element => {
+): React.ReactElement => {
   const { id, className, isPageHeading, children } = props;
 
   const extraAttributes = Attributes.ariaAndData(props);

--- a/src/components/FormGroup.tsx
+++ b/src/components/FormGroup.tsx
@@ -33,7 +33,7 @@ export interface FormGroupProps extends React.AriaAttributes, DataAttributes {
  */
 export const FormGroup: React.FunctionComponent<FormGroupProps> = (
   props: FormGroupProps
-): JSX.Element => {
+): React.ReactElement => {
   const { id, className, error, children } = props;
 
   const extraAttributes = Attributes.ariaAndData(props);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -57,7 +57,7 @@ export interface HeaderProps extends React.AriaAttributes, DataAttributes {
  */
 export const Header: React.FunctionComponent<HeaderProps> = (
   props: HeaderProps
-): JSX.Element => {
+): React.ReactElement => {
   const {
     id,
     className,

--- a/src/components/Hint.tsx
+++ b/src/components/Hint.tsx
@@ -24,7 +24,7 @@ export interface HintProps extends React.AriaAttributes, DataAttributes {
  */
 export const Hint: React.FunctionComponent<HintProps> = (
   props: HintProps
-): JSX.Element => {
+): React.ReactElement => {
   const { id, className, children } = props;
 
   const extraAttributes = Attributes.ariaAndData(props);

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -25,7 +25,7 @@ export interface LabelProps extends React.AriaAttributes, DataAttributes {
  */
 export const Label: React.FunctionComponent<LabelProps> = (
   props: LabelProps
-): JSX.Element => {
+): React.ReactElement => {
   const { id, className, labelFor, children } = props;
 
   const extraAttributes = Attributes.ariaAndData(props);

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -28,7 +28,7 @@ export interface LinkProps extends React.AriaAttributes, DataAttributes {
  */
 export const Link: React.FunctionComponent<LinkProps> = (
   props: LinkProps
-): JSX.Element => {
+): React.ReactElement => {
   const { id, className, href, children } = props;
 
   const extraAttributes = Attributes.ariaAndData(props);

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -44,7 +44,7 @@ export interface ListProps extends React.AriaAttributes, DataAttributes {
  */
 export const List: React.FunctionComponent<ListProps> = (
   props: ListProps
-): JSX.Element => {
+): React.ReactElement => {
   const { id, className, type, items } = nullValuesAsUndefined(props);
 
   const extraAttributes = Attributes.ariaAndData(props);

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -33,7 +33,7 @@ export interface MainProps extends React.AriaAttributes, DataAttributes {
  */
 export const Main: React.FunctionComponent<MainProps> = (
   props: MainProps
-): JSX.Element => {
+): React.ReactElement => {
   const { id, className, children } = props;
 
   const extraAttributes = Attributes.ariaAndData(props);

--- a/src/components/PageAnnouncement.tsx
+++ b/src/components/PageAnnouncement.tsx
@@ -33,7 +33,7 @@ export interface PageAnnouncementProps
  */
 export const PageAnnouncement: React.FunctionComponent<PageAnnouncementProps> = (
   props: PageAnnouncementProps
-): JSX.Element => {
+): React.ReactElement => {
   const { id, className, title, children } = props;
 
   const extraAttributes = Attributes.ariaAndData(props);

--- a/src/components/SummaryList.tsx
+++ b/src/components/SummaryList.tsx
@@ -48,7 +48,7 @@ export interface SummaryListProps extends React.AriaAttributes, DataAttributes {
  */
 export const SummaryList: React.FunctionComponent<SummaryListProps> = (
   props: SummaryListProps
-): JSX.Element => {
+): React.ReactElement => {
   const { id, className, rows } = props;
 
   const extraAttributes = Attributes.ariaAndData(props);

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -25,7 +25,7 @@ export interface TagProps extends React.AriaAttributes, DataAttributes {
  */
 export const Tag: React.FunctionComponent<TagProps> = (
   props: TagProps
-): JSX.Element => {
+): React.ReactElement => {
   const { id, className, children } = props;
 
   const extraAttributes = Attributes.ariaAndData(props);

--- a/src/components/icons/HackneyLogo.tsx
+++ b/src/components/icons/HackneyLogo.tsx
@@ -31,7 +31,7 @@ export interface HackneyLogoProps extends React.AriaAttributes, DataAttributes {
  */
 export const HackneyLogo: React.FunctionComponent<HackneyLogoProps> = (
   props: HackneyLogoProps
-): JSX.Element => {
+): React.ReactElement => {
   const { className, width, height } = nullValuesAsUndefined(props);
 
   const extraAttributes = Attributes.ariaAndData(props);

--- a/src/components/icons/StartButtonIcon.tsx
+++ b/src/components/icons/StartButtonIcon.tsx
@@ -21,7 +21,7 @@ export interface StartButtonIconProps
  */
 export const StartButtonIcon: React.FunctionComponent<StartButtonIconProps> = (
   props: StartButtonIconProps
-): JSX.Element => {
+): React.ReactElement => {
   const { className } = props;
   const extraAttributes = Attributes.ariaAndData(props);
   // This SVG is sourced from `govuk-frontend@3.3.0`. See

--- a/src/components/typography/Heading.tsx
+++ b/src/components/typography/Heading.tsx
@@ -41,7 +41,7 @@ export interface HeadingProps extends React.AriaAttributes, DataAttributes {
  */
 export const Heading: React.FunctionComponent<HeadingProps> = (
   props: HeadingProps
-): JSX.Element => {
+): React.ReactElement => {
   const { id, className, level, children } = nullValuesAsUndefined(props);
 
   const extraAttributes = Attributes.ariaAndData(props);

--- a/src/components/typography/Paragraph.tsx
+++ b/src/components/typography/Paragraph.tsx
@@ -49,7 +49,7 @@ export interface ParagraphProps extends React.AriaAttributes, DataAttributes {
  */
 export const Paragraph: React.FunctionComponent<ParagraphProps> = (
   props: ParagraphProps
-): JSX.Element => {
+): React.ReactElement => {
   const { id, className, size, children } = nullValuesAsUndefined(props);
 
   const extraAttributes = Attributes.ariaAndData(props);


### PR DESCRIPTION
`React.ReactNode` includes `React.ReactElement`, not `JSX.Element`.
