### PR TITLE
MT3-352 Fix fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix fonts (includes update to lbh-frontend package)
+
 ## [0.0.5] - 12-12-2019
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -2219,6 +2219,7 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -4515,7 +4516,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "filename-reserved-regex": {
       "version": "2.0.0",
@@ -4691,6 +4693,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
       "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "bindings": "^1.5.0",
         "nan": "^2.12.1",
@@ -4700,7 +4703,8 @@
         "abbrev": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -4710,12 +4714,14 @@
         "aproba": {
           "version": "1.2.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -4738,7 +4744,8 @@
         "chownr": {
           "version": "1.1.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
@@ -4758,12 +4765,14 @@
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "debug": {
           "version": "3.2.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -4771,22 +4780,26 @@
         "deep-extend": {
           "version": "0.6.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fs-minipass": {
           "version": "1.2.7",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.6.0"
           }
@@ -4794,12 +4807,14 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -4815,6 +4830,7 @@
           "version": "7.1.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -4827,12 +4843,14 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -4841,6 +4859,7 @@
           "version": "3.0.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
@@ -4849,6 +4868,7 @@
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -4862,7 +4882,8 @@
         "ini": {
           "version": "1.3.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -4875,7 +4896,8 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
@@ -4903,6 +4925,7 @@
           "version": "1.3.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.9.0"
           }
@@ -4918,12 +4941,14 @@
         "ms": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "needle": {
           "version": "2.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
@@ -4934,6 +4959,7 @@
           "version": "0.14.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
@@ -4951,6 +4977,7 @@
           "version": "4.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -4960,6 +4987,7 @@
           "version": "1.1.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
@@ -4967,12 +4995,14 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.7",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1"
@@ -4982,6 +5012,7 @@
           "version": "4.1.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -4997,7 +5028,8 @@
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "once": {
           "version": "1.4.0",
@@ -5010,17 +5042,20 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -5029,17 +5064,20 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -5050,7 +5088,8 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -5058,6 +5097,7 @@
           "version": "2.3.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -5072,6 +5112,7 @@
           "version": "2.7.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -5084,27 +5125,32 @@
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "sax": {
           "version": "1.2.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.7.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "string-width": {
           "version": "1.0.2",
@@ -5120,6 +5166,7 @@
           "version": "1.1.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -5135,12 +5182,14 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "tar": {
           "version": "4.4.13",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -5154,12 +5203,14 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
@@ -7105,9 +7156,9 @@
       "dev": true
     },
     "lbh-frontend": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/lbh-frontend/-/lbh-frontend-1.6.0.tgz",
-      "integrity": "sha512-47lp7db4Uh4862L9D2JlamRihGaDIfr0kiXoqUwkFUdQSq94/5EXZutKDm1QVUNDB4zipFvG8aWtEoPhom/O+A==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/lbh-frontend/-/lbh-frontend-1.6.2.tgz",
+      "integrity": "sha512-FdWjt988iMt463wptwZwumRoqJvnsktTcf2ztcXgMudrK2H5cer8ZL2g1JWdujGWb+yh0r8FZK/liLKPz+C5Ag==",
       "dev": true
     },
     "lcid": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "husky": "^3.1.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.9.0",
-    "lbh-frontend": "^1.6.0",
+    "lbh-frontend": "^1.6.2",
     "node-sass": "^4.13.0",
     "prettier": "^1.19.1",
     "pretty-quick": "^2.0.1",

--- a/src/components/SummaryList.scss
+++ b/src/components/SummaryList.scss
@@ -1,0 +1,6 @@
+$govuk-font-family: "Montserrat";
+$govuk-include-default-font-face: false;
+
+// Inherits directly from `govuk-frontend`, rather than `lbh-frontend`, due to
+// `lbh-frontend` having no summary list component at time of implementation.
+@import "node_modules/govuk-frontend/govuk/components/summary-list/_summary-list.scss";

--- a/src/components/SummaryList.tsx
+++ b/src/components/SummaryList.tsx
@@ -4,9 +4,7 @@ import React from "react";
 
 import { Attributes, DataAttributes } from "../helpers/Attributes";
 
-// Inherits directly from `govuk-frontend`, rather than `lbh-frontend`, due to
-// `lbh-frontend` having no summary list component at time of implementation.
-import "govuk-frontend/govuk/components/summary-list/_summary-list.scss";
+import "./SummaryList.scss";
 
 /**
  * A unit of information to display in a row of a {@link SummaryList}.


### PR DESCRIPTION
# What?

- update lbh-frontend to 1.6.2 which contains a fix to explicitly tell govuk-frontend not to load local fonts
- add a SummaryList.scss file to set the govuk-font and explicitly tell govuk-frontend not to load local fonts. (This only applies to SummaryList as it's the only place where we're loading scss directly from govuk-frontend).

# Why?

Prevent 404s because code is currently trying to load fonts from assets/fonts

# Next steps

Will require this to be released in order to fix the issue in THC.
