### PR TITLE
Release/v0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+### Fixed
+
+## [0.0.10] - 06-02-2020
+
 ### Fixed
 
 - Fix `Textarea` to use `value`, not `children`
@@ -113,7 +119,9 @@ and this project adheres to
 - `PageAnnouncement` component
 
 [unreleased]:
-  https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.9...HEAD
+  https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.10...HEAD
+[0.0.10]:
+  https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.9...v0.0.10
 [0.0.9]:
   https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.8...v0.0.9
 [0.0.8]:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lbh-frontend-react",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lbh-frontend-react",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "London Borough of Hackney's React component library",
   "license": "MIT",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
### Fixed

- Fix `Textarea` to use `value`, not `children`