### PR TITLE
Release/v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.3.0] - 22-07-2020
+
+### Added
+
+- Added phase banner component
+
 ## [0.2.0] - 14-07-2020
 
 ### Added
@@ -161,32 +167,18 @@ and this project adheres to
 - `Button` component
 - `PageAnnouncement` component
 
-[unreleased]:
-  https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.14...HEAD
-[0.0.14]:
-  https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.13...v0.0.14
-[0.0.13]:
-  https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.12...v0.0.13
-[0.0.12]:
-  https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.11...v0.0.12
-[0.0.11]:
-  https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.10...v0.0.11
-[0.0.10]:
-  https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.9...v0.0.10
-[0.0.9]:
-  https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.8...v0.0.9
-[0.0.8]:
-  https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.7...v0.0.8
-[0.0.7]:
-  https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.6...v0.0.7
-[0.0.6]:
-  https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.5...v0.0.6
-[0.0.5]:
-  https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.4...v0.0.5
-[0.0.4]:
-  https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.3...v0.0.4
-[0.0.3]:
-  https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.2...v0.0.3
-[0.0.2]:
-  https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.1...v0.0.2
+[unreleased]: https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.14...HEAD
+[0.0.14]: https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.13...v0.0.14
+[0.0.13]: https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.12...v0.0.13
+[0.0.12]: https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.11...v0.0.12
+[0.0.11]: https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.10...v0.0.11
+[0.0.10]: https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.9...v0.0.10
+[0.0.9]: https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.8...v0.0.9
+[0.0.8]: https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.7...v0.0.8
+[0.0.7]: https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.6...v0.0.7
+[0.0.6]: https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.5...v0.0.6
+[0.0.5]: https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.4...v0.0.5
+[0.0.4]: https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.3...v0.0.4
+[0.0.3]: https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/LBHackney-IT/lbh-frontend-react/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/LBHackney-IT/lbh-frontend-react/releases/tag/v0.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lbh-frontend-react",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lbh-frontend-react",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "London Borough of Hackney's React component library",
   "license": "MIT",
   "main": "dist/cjs/index.js",

--- a/src/components/PhaseBanner.test.tsx
+++ b/src/components/PhaseBanner.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { create } from "react-test-renderer";
+import { PhaseBanner } from "./PhaseBanner";
+import { shallow } from "enzyme";
+
+describe("phase banner", () => {
+  it("renders the component successfully", () => {
+    const component = create(
+      <PhaseBanner phase={"BETA"} url={"https://www.hackney.gov.uk"} />
+    );
+
+    expect(component).toMatchInlineSnapshot(`
+      <div
+        className="phase-banner"
+      >
+        <p
+          className="lbh-body"
+        >
+          <strong
+            className="govuk-tag lbh-tag"
+          >
+            <span
+              data-test="phase"
+            >
+              BETA
+            </span>
+          </strong>
+           
+          This is a new service – your
+           
+          <a
+            className="govuk-link lbh-link"
+            href="https://www.hackney.gov.uk"
+            target="_blank"
+          >
+            feedback
+          </a>
+           
+          (online only, opens in a new tab) will help us to improve it.
+        </p>
+        <hr />
+      </div>
+    `);
+  });
+
+  it("displays the phase it is passed", () => {
+    const alphaComponent = shallow(<PhaseBanner phase="ALPHA" url="" />);
+    const betaComponent = shallow(<PhaseBanner phase="BETA" url="" />);
+
+    expect(alphaComponent.find({ "data-test": "phase" }).text()).toBe("ALPHA");
+    expect(betaComponent.find({ "data-test": "phase" }).text()).toBe("BETA");
+  });
+});

--- a/src/components/PhaseBanner.tsx
+++ b/src/components/PhaseBanner.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Paragraph } from "./typography/Paragraph";
+import { Tag } from "./Tag";
+import { Link } from "./Link";
+
+/**
+ * The prop types for the {@link PhaseBanner} component.
+ *
+ * @noInheritDoc
+ */
+
+export interface PhaseBannerProps {
+  /**
+   * A string value that will be displayed in the phase icon in the banner.
+   * This will typically be either "ALPHA", or "BETA"
+   */
+  phase: string;
+  /**
+   * A url to be applied to the feedback link. Provide a link to your relevant feedback page for the service.
+   */
+  url: string;
+}
+
+/**
+ * A component to add a banner to your application, alerting users to its alpha or beta status.
+ */
+export const PhaseBanner = (props: PhaseBannerProps): React.ReactElement => {
+  return (
+    <div className="phase-banner">
+      <Paragraph>
+        <Tag>
+          <span data-test="phase">{props.phase}</span>
+        </Tag>{" "}
+        This is a new service – your{" "}
+        <Link href={props.url || ""} target="_blank">
+          feedback
+        </Link>{" "}
+        (online only, opens in a new tab) will help us to improve it.
+      </Paragraph>
+      <hr />
+    </div>
+  );
+};

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -158,7 +158,7 @@ describe("given data", () => {
                 data-test="body-cell"
                 role="cell"
               >
-                17/07/2020
+                25/07/2020
                  
                 <span
                   className="icon"
@@ -210,7 +210,7 @@ describe("given data", () => {
                 data-test="body-cell"
                 role="cell"
               >
-                13/07/2020
+                21/07/2020
                  
                 <span
                   className="icon"

--- a/stories/PhaseBanner.stories.tsx
+++ b/stories/PhaseBanner.stories.tsx
@@ -1,0 +1,11 @@
+import { storiesOf } from "@storybook/react";
+import React from "react";
+import { PhaseBanner } from "../src/components/PhaseBanner";
+
+storiesOf("PhaseBanner", module)
+  .add("with Beta prop", () => (
+    <PhaseBanner phase={"BETA"} url={"https://www.hackney.gov.uk"} />
+  ))
+  .add("with ALPHA prop", () => (
+    <PhaseBanner phase={"ALPHA"} url={"https://www.hackney.gov.uk"} />
+  ));


### PR DESCRIPTION


# What?

Added phase banner component to lbh-frontend-react
Published component to storybook

# Why?

This change makes the phase banner reusable in Hackney projects


![image](https://user-images.githubusercontent.com/57630381/88168102-d5b2da00-cc11-11ea-8400-b4d7b957b005.png)


