### PR TITLE
Documentation fix for Export error on new lbh frontend react components

### DIFF
--- a/FixComponentExport.md
+++ b/FixComponentExport.md
@@ -1,0 +1,45 @@
+# Fix for components that don't appear to have been exported from lbh-frontend-react npm package
+
+## PROBLEM:
+
+It has been noted that when new components are added to the lbh-frontend-react
+library, once they are used in other projects they can cause an error declaring
+that no export has been created for that component. This leaves the component
+discoverable but unusable.
+
+## FIX:
+
+1. Ensure your project is using the most up to date version of
+   lbh-frontend-react npm package by examining its package.json file. If you
+   must update it manually, update your npm packages afterwards by running:
+
+```sh
+npm i
+```
+
+Ensure your package-lock.json file lbh-frontend-react npm version matches the
+version in package.json. Check to see if this has resolved the export error for
+the lbh-frontend-react component.
+
+2. If error persists, try a clean install by running:
+
+```sh
+npm ci
+```
+
+Check to see if this has resolved the export error for the lbh-frontend-react
+component.
+
+3. If error persists, try a cache clean by running:
+
+```sh
+npm cache clean --force
+```
+
+Check to see if this has resolved the export error for the lbh-frontend-react
+component.
+
+4. Restart your IDE
+
+These steps have been found to resolve export errors for lbh-frontend-react
+components.

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ See the
 [documentation website](https://lbhackney-it.github.io/lbh-frontend-react/docs/)
 (generated with [TypeDoc](https://typedoc.org/)).
 
-
 ## Export errors
 
-Please see `FixComponentExport.md` file for steps to resolve any errors around components being exported
+Please see `FixComponentExport.md` file for steps to resolve any errors around
+components being exported
 
 ## For contributors
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ See the
 [documentation website](https://lbhackney-it.github.io/lbh-frontend-react/docs/)
 (generated with [TypeDoc](https://typedoc.org/)).
 
+
+## Export errors
+
+Please see `FixComponentExport.md` file for steps to resolve any errors around components being exported
+
 ## For contributors
 
 ### Running the tests


### PR DESCRIPTION
# What?

Steps to fix export error for lbh-frontend-react components

# Why?

When importing components from the NPM package, sometimes components were discoverable but threw a "no export error" making them unusable